### PR TITLE
Adapt MooTools 1.3 syntax

### DIFF
--- a/Source/array-sortby.js
+++ b/Source/array-sortby.js
@@ -1,7 +1,7 @@
 ﻿/*
 ---
 script: array-sortby.js
-version: 1.2.2
+version: 1.2.3
 description: Array.sortBy is a prototype function to sort arrays of objects by a given key.
 license: MIT-style
 download: http://mootools.net/forge/p/array_sortby
@@ -18,7 +18,7 @@ provides:
 - Array.sortBy
 
 requires:
-- core/1.2.4:Array
+- core/1.3:Array
 
 ...
 */
@@ -50,15 +50,18 @@ requires:
 		return 0;
 	};
 
-	Array.implement('sortBy', function(){
-		keyPaths.empty();
-		Array.each(arguments, function(argument) {
-			switch ($type(argument)) {
-				case "array": saveKeyPath(argument); break;
-				case "string": saveKeyPath(argument.match(/[+-]|[^.]+/g)); break;
-			}
-		});
-		return this.sort(comparer);
+	Array.implement({
+		sortBy: function(){
+			keyPaths.empty();
+
+			Array.each(arguments, function(argument) {
+				switch (typeOf(argument)) {
+					case "array": saveKeyPath(argument); break;
+					case "string": saveKeyPath(argument.match(/[+-]|[^.]+/g)); break;
+				}
+			});
+			return this.sort(comparer);
+		}
 	});
 
 })();


### PR DESCRIPTION
While using Array.sortBy with MooTools 1.3, there are some updates on a function call and a deprecated function.
